### PR TITLE
Add a user-friendly error when undeclared hooks are used

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -753,3 +753,23 @@ it('should generate style sheet and props with custom properties and themes with
     }
   `)
 })
+
+it('should throw an error when trying to use a hook that is not defined', () => {
+  const { create } = nanocss({
+    hooks: [':hover'],
+    debug: true,
+  })
+
+  expect(() => {
+    // @ts-expect-error This is a type error but can still happen in runtime if
+    // using NanoCSS in JavaScript or when using it as a replacement for StyleX.
+    create({
+      root: {
+        color: {
+          default: 'black',
+          ':focus': 'red',
+        },
+      },
+    })
+  }).toThrowErrorMatchingInlineSnapshot(`[Error: [nanocss] ":focus" was used but not declared in the hooks array. Please add it to the hooks array.]`)
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,14 @@ function nanocss<T extends HookNames>({
                   value: current.value[condition],
                 })
               } else {
+                if (!hooks.includes(condition as T)) {
+                  throw new Error(
+                    `[nanocss] ${JSON.stringify(
+                      condition
+                    )} was used but not declared in the hooks array. Please add it to the hooks array.`
+                  )
+                }
+
                 stack.push({
                   conditions: [...current.conditions, condition],
                   value: current.value[condition],


### PR DESCRIPTION
# Why

When using NanoCSS as a replacement for StyleX or in a JavaScript project, invalid hooks used throw a cryptic message without clear contexts.
This PR implements an user-friendly error message that clearly shows invalid hooks are used.

<img width="546" alt="Screenshot 2024-08-22 at 23 15 44" src="https://github.com/user-attachments/assets/88abb35c-2845-4321-b14d-25e273f3e4d9">

# How

Validate hooks and throws an error message like `[nanocss] ":focus" was used but not declared in the hooks array. Please add it to the hooks array.`

# Test Plan
- Added a unit test