### PR TITLE
Maintian variable names for keys that start with --

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -544,6 +544,37 @@ it('should generate style sheet and props with custom properties', () => {
   `)
 })
 
+it('should generate style sheet and props with custom properties with passthrough', () => {
+  const { styleSheet, create, props, defineVars } = nanocss({
+    hooks: [],
+    debug: true,
+  })
+
+  expect(styleSheet()).toMatchInlineSnapshot(`
+    "* {
+    }
+    "
+  `)
+
+  const colors = defineVars({
+    '--primary': 'green',
+  })
+
+  const styles = create({
+    root: {
+      color: colors['--primary'],
+    },
+  })
+
+  expect(props(styles.root)).toMatchInlineSnapshot(`
+    {
+      "style": {
+        "color": "var(--primary, green)",
+      },
+    }
+  `)
+})
+
 it('should generate style sheet and props with custom properties and can override with var name as property key', () => {
   const { styleSheet, create, props, defineVars } = nanocss({
     hooks: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,7 +256,7 @@ function nanocss<T extends HookNames>({
     const nameToKeyMap: Record<string, string> = {}
 
     for (const [key, value] of Object.entries(tokens)) {
-      const name = `--_nanocss_var_${id++}`
+      const name = key.startsWith('--') ? key : `--_nanocss_var_${id++}`
       style[name] = value
       nameToKeyMap[name] = key
     }


### PR DESCRIPTION
# Why
According to [this PR](https://github.com/facebook/stylex/pull/584), `defineVars` API should support variable names that start with `--` to match the variable names exactly as defined, rather than using automatic unique var generation.
This allows seamless interoperability with existing global css.

This PR implements StyleX-compatible handling of variable names for keys that start with `--`.

# How

Opt out of automatic var name generation when keys start with `--`.

# Test Plan
- Added a unit test